### PR TITLE
fix: corrige exibição coorientador

### DIFF
--- a/conf-comandos.sty
+++ b/conf-comandos.sty
@@ -38,7 +38,9 @@
         \noindent Banca Examinadora:
         
         \assinatura{\imprimirorientador, Dr.} 
-        \assinatura{\imprimircoorientador, Dr.}
+        \@ifundefined{\imprimircoorientador}{}{
+        	\assinatura{\imprimircoorientador, Dr.}
+        }
         \assinatura{Mauro Tavares Peraça, Dr.}
         %\assinatura{Convidado 2, Dr.}
         \assinatura{Muriel Bittencourt de Liz, Dr.}

--- a/ifsc-tcc-abntex2.cls
+++ b/ifsc-tcc-abntex2.cls
@@ -212,7 +212,9 @@
                 \imprimirorientadorRotulo~Prof. Dr. \imprimirorientador\par
   
                 \vspace*{1.0cm}
-                \imprimircoorientadorRotulo~Prof. Dr. \imprimircoorientador%
+                	\@ifundefined{\imprimircoorientador}{}{
+	                \imprimircoorientadorRotulo~Prof. Dr. \imprimircoorientador
+                	}
             \end{SingleSpacing}
         \end{minipage}%
         \vspace*{\fill}


### PR DESCRIPTION
Caso não houvesse coorientador seria mostrado da seguinte forma o nome do professor orientador.
![image](https://user-images.githubusercontent.com/19908659/120312768-83216000-c2af-11eb-937e-03ac9e4dc957.png)
É possível perceber que existe uma impressão equivocada logo abaixo do nome do orientador.

O mesmo ocorre na folha de membros da banca:
![image](https://user-images.githubusercontent.com/19908659/120312939-bf54c080-c2af-11eb-98fb-1785b87b72a1.png)
Que para o caso do coorientador que não existe fica impresso apenas ", Dr".

Dessa forma, esse PR busca corrigir esses dois pontos.